### PR TITLE
Plugin file linter updates; package updates

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -212,7 +212,7 @@
     "no-useless-constructor": "error",
     "no-useless-rename": "error",
     "no-var": "error",
-    "object-shorthand": "error",
+    "object-shorthand": ["error", "never"], // MODIFIED webcom
     "prefer-arrow-callback": "error",
     "prefer-const": "error",
     "prefer-numeric-literals": "error",

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -43,9 +43,9 @@ rules:
   final-newline:
     - 1
     - include: true
-  force-attribute-nesting: 1
-  force-element-nesting: 1
-  force-pseudo-nesting: 1
+  force-attribute-nesting: 0 # Modified - allow unnested selectors for more convenient selector overrides
+  force-element-nesting: 0 # Modified - allow unnested selectors for more convenient selector overrides
+  force-pseudo-nesting: 0 # Modified - allow unnested selectors for more convenient selector overrides
   function-name-format:
     - 1
     - allow-leading-underscore: true
@@ -69,7 +69,7 @@ rules:
     - 1
     - allow-leading-underscore: true
       convention: hyphenatedlowercase
-  mixins-before-declarations: 1
+  mixins-before-declarations: 0 # Modified - accommodates media query-like mixin includes within blocks
   nesting-depth:
     - 1
     - max-depth: 3
@@ -137,7 +137,7 @@ rules:
         - dppx
         - '%'
       per-property:
-        line-height: []
+        line-height: [] # Modified - always use unitless line-height values
   quotes:
     - 1
     - style: single

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,7 @@ if (fs.existsSync('./gulp-config.json')) {
 function lintSCSS(src) {
   return gulp.src(src)
     .pipe(sassLint())
+    .pipe(sassLint.format())
     .pipe(sassLint.failOnError());
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4198,69 +4198,6 @@
         }
       }
     },
-    "gulp-add-src": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gulp-add-src/-/gulp-add-src-1.0.0.tgz",
-      "integrity": "sha512-wmqf71/V/W4Ffi9lduaWAgNFcJW60TRqgc2lRv94d6I7j4rjHtVMHjnbwDH8RF0czGfJqYbs+ruecZXmwJopCQ==",
-      "dev": true,
-      "requires": {
-        "event-stream": "~3.1.5",
-        "streamqueue": "^0.1.1",
-        "through2": "~0.4.1",
-        "vinyl-fs": "~3.0.2"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "object-keys": {
-          "version": "0.4.0",
-          "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
-          "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "through2": {
-          "version": "0.4.2",
-          "resolved": "http://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
-          "integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~1.0.17",
-            "xtend": "~2.1.1"
-          }
-        },
-        "xtend": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
-          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
-          "dev": true,
-          "requires": {
-            "object-keys": "~0.4.0"
-          }
-        }
-      }
-    },
     "gulp-autoprefixer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-6.0.0.tgz",
@@ -8517,42 +8454,6 @@
       "requires": {
         "commander": "^2.2.0",
         "limiter": "^1.0.5"
-      }
-    },
-    "streamqueue": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/streamqueue/-/streamqueue-0.1.3.tgz",
-      "integrity": "sha1-sQ1lFYr1ec46X0jJJ20B2yPU+LU=",
-      "dev": true,
-      "requires": {
-        "isstream": "~0.1.1",
-        "readable-stream": "~1.0.33"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
     },
     "string-width": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "browser-sync": "^2.26.3",
     "eslint": "^5.9.0",
     "gulp": "^4.0.0",
-    "gulp-add-src": "^1.0.0",
     "gulp-autoprefixer": "^6.0.0",
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^3.10.0",


### PR DESCRIPTION
- Ports over sass-lint rule adjustments recently added to the Athena Framework.  See #17
- Remove gulp-add-src from package.json.  See #18
- Disabled "object-shorthand" eslint rule in .eslintrc.json.  See #19.
- Enabled `lintSCSS()` linter output in console when Sass linting is performed.  See #20.